### PR TITLE
Add GitHub ribbon and WIP note at the bottom

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -36,6 +36,32 @@
     body {
         max-width: 90vw
     }
+
+    .git-ribbon {
+      background-color: #5bb006;
+      overflow: hidden;
+      /* top left corner */
+      position: absolute;
+      right: -3em;
+      top: 2.5em;
+      /* 45 deg ccw rotation */
+      transform: rotate(45deg);
+      /* shadow */
+      box-shadow: 0 0 1em #888;
+    }
+
+    .git-ribbon a {
+      border: 1px solid #faa;
+      color: #fff;
+      display: block;
+      font: bold 81.25% 'Helvetiva Neue', Helvetica, Arial, sans-serif;
+      margin: 0.05em 0 0.075em 0;
+      padding: 0.5em 3.5em;
+      text-align: center;
+      text-decoration: none;
+      /* shadow */
+      text-shadow: 0 0 0.5em #444;
+    }
     
     @media (prefers-color-scheme: dark) {
         :root {
@@ -58,8 +84,13 @@
   <header>
     <h1>Welcome to our <span style=color:#5bb006;>NuShell</span> demo</h1>
   </header>
+  
   <noscript>This page contains webassembly and javascript content, please enable
     javascript in your browser.</noscript>
+
+  <div class="git-ribbon">
+    <a href="https://github.com/nushell/demo" rel="me">Contribute on GitHub</a>
+  </div>
 
   <p id="examples">
     <button data-command="help commands">list all commands</button>
@@ -74,6 +105,9 @@ help commands</textarea>
 
   <br /><br />
   <p id="demo"></p>
+  <p>
+    <small>This is a work in progress. Not all commands work and some errors break everything, requiring a page reload. <a target="_blank" href="https://github.com/nushell/demo/issues/18">More details on GitHub</a></small>
+  </p>
   <script src="./browserfs.min.js"></script>
   </script>
   <script src="./bootstrap.js"></script>


### PR DESCRIPTION
ribbon in the top right, based on https://gist.github.com/thunsaker/1188641/61939b58f5e37922602d8e7dd65696e6628b5b59 but with a green background and in the top-right

A link to the "WIP" issue with a note at the bottom

Fixes #41
Fixes #46

Preview: 

<img width="1393" alt="Screenshot 2020-08-01 at 12 35 52" src="https://user-images.githubusercontent.com/52585/89099973-8e87ce80-d3f3-11ea-9f22-651d35f2239f.png">