### PR TITLE
add button to pivot overflowing tables

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -86,6 +86,19 @@ async function runCommand() {
       commandCell.appendChild(link);
     }
   }
+  const tables = document.querySelectorAll("#demo > table");
+  tables.forEach((table, index) => {
+    if (table.clientWidth > document.body.clientWidth) {
+      const button = document.createElement("button");
+      button.textContent = "Pivot this overflowing table";
+      button.setAttribute(
+        "data-command",
+        `${inputsRaw[index]} | pivot | rename key value`
+      );
+      button.style.marginBottom = "0.5rem";
+      table.parentNode.insertBefore(button, table.nextSibling);
+    }
+  });
 }
 
 document.getElementById("run-nu").addEventListener("click", (event) => {
@@ -100,11 +113,16 @@ for (const example of examples) {
   button.textContent = example.label;
   examplesContainer.appendChild(button);
 }
-examplesContainer.addEventListener("click", (event) => {
-  nuinput.value = /** @type HTMLButtonElement */ (event.target).getAttribute(
+// copied from https://github.com/nushell/demo/pull/35/files#diff-f0b0d6a8e47512ae7354ef98e85c5ffbR106
+document.body.addEventListener("click", (event) => {
+  const command = /** @type HTMLButtonElement */ (event.target).getAttribute(
     "data-command"
   );
   runCommand();
+  if (command) {
+    nuinput.value = command;
+    runCommand();
+  }
 });
 
 nuinput.addEventListener("keydown", (event) => {


### PR DESCRIPTION
Also uses `rename` to give the (likely) two columns nicer names.

Fixes #29

Table with overflow:
<img width="1375" alt="Screenshot 2020-08-01 at 13 11 05" src="https://user-images.githubusercontent.com/52585/89100601-8d0cd500-d3f8-11ea-9256-a1e5aaf0eef0.png">

After running with the extra `| pivot | rename key value`:
<img width="1031" alt="Screenshot 2020-08-01 at 13 11 14" src="https://user-images.githubusercontent.com/52585/89100597-7f574f80-d3f8-11ea-82e6-9122aec947c3.png">
