### PR TITLE
Add features for instant to get 'now'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.62"
 wasm-bindgen = "0.2.70"
 wasm-bindgen-futures = "0.4.20"
 getrandom = { version = "0.2.2", features = ["js"] }
+instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default


### PR DESCRIPTION
Add some features to the `instant` crate so we can have a somewhat function `now`, which some crates rely on.